### PR TITLE
Refactor: Remove API key requirement and simplify route calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,6 @@
 <body>
     <h1>位置情報テスト</h1>
     <p>現在地の情報を取得します...</p>
-    <div>
-        <label for="apiKey">OpenRouteService APIキー:</label>
-        <input type="text" id="apiKey" placeholder="APIキーを入力してください">
-        <button onclick="setApiKey()">APIキーを設定</button>
-    </div>
     <button onclick="getLocation()">位置情報を取得</button>
     <div id="location-info"></div>
     <script src="script.js"></script>


### PR DESCRIPTION
I've removed the OpenRouteService API key input and related functionality. The kilopost calculation now uses a simpler method based on straight-line distances between your location and the start/end points of the highway as defined in highways.json.

Key changes:
- Removed API key input field and setting logic from index.html and script.js.
- Deleted the `fetchRouteDistance` function which relied on the OpenRouteService API.
- Modified `calculateKilopost` to use a ratio of straight-line distances for estimating the kilopost.
- The Overpass API usage for fetching highway data and facilities remains unchanged and functional.

This change allows the application to provide core functionality without requiring you to obtain and enter an external API key.